### PR TITLE
Update workflow import

### DIFF
--- a/.github/workflows/sdk-type-check.yml
+++ b/.github/workflows/sdk-type-check.yml
@@ -14,5 +14,5 @@ permissions:
 
 jobs:
   typecheck-latest:
-    uses: papermoonio/workflows/.github/workflows/wormhole-demo-typecheck.yml@main
+    uses: wormhole-foundation/workflows/.github/workflows/wormhole-demo-typecheck.yml@main
     secrets: inherit


### PR DESCRIPTION
This pull request updates the workflow configuration to reference the correct repository for type checking in the SDK CI process.

CI workflow update:

* [`.github/workflows/sdk-type-check.yml`](diffhunk://#diff-763308f5e11ab32090c3513f167589e2e72a61432100ea45c58e45c496936041L17-R17): Changed the `typecheck-latest` job to use the workflow from the `wormhole-foundation` repository instead of `papermoonio`, ensuring the workflow points to the official source.